### PR TITLE
add missing dependency "vue-easy-toast"

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "pug": "^2.0.0-beta6",
     "pug-loader": "^2.3.0",
     "vue-clickaway": "^2.1.0",
+    "vue-easy-toast": "^1.0.1",
     "vue-form-generator": "^2.0.0-beta6",
     "vue-js-toggle-button": "^1.0.5",
     "vue-loader": "^9.9.5",


### PR DESCRIPTION
I'm not sure about the version so I added the latest one. But when this dependency is missing, I get this error:

    ERROR in ./src/main.js
    Module not found: Error: Can't resolve 'vue-easy-toast' in '/root/yayata/src'
    @ ./src/main.js 12:0-35
    @ multi ./src/main.js

Signed-off-by: Pavel Pulec <kayn@inuits.eu>